### PR TITLE
config directive "reject-unless-verified = true" will cause the milter t...

### DIFF
--- a/batv-milter.cpp
+++ b/batv-milter.cpp
@@ -220,6 +220,10 @@ namespace {
 				if (batv_ctx->batv_rcpt.tag_type == "prvs") {
 					if (prvs_validate(batv_ctx->batv_rcpt, config->address_lifetime, *batv_ctx->batv_rcpt_key)) {
 						status = "valid";
+					} else {
+						if (config->reject_unless_verified) {
+							return milter_status(Config::FAILURE_REJECT);
+						}
 					}
 				}
 

--- a/config.cpp
+++ b/config.cpp
@@ -202,6 +202,14 @@ void	Config::set (const std::string& directive, const std::string& value)
 		} else {
 			throw Config_error("Invalid value for 'on-internal-error' directive (should be 'tempfail', 'accept', or 'reject'): " + value);
 		}
+	} else if (directive == "reject-unless-verified") {
+		if (value == "yes" || value == "true" || value == "on" || value == "1") {
+			reject_unless_verified = true;
+		} else if (value == "no" || value == "false" || value == "off" || value == "0") {
+			reject_unless_verified = false;
+		} else {
+			throw Config_error("Invalid value for 'reject-unless-verified' directive (should be 'true' or 'false')");
+		}
 	} else {
 		throw Config_error("Invalid config directive " + directive);
 	}

--- a/config.hpp
+++ b/config.hpp
@@ -62,6 +62,7 @@ namespace batv {
 		unsigned int		address_lifetime;	// in days, how long BATV address is valid
 		char			sub_address_delimiter;	// e.g. "+"
 		Failure_mode		on_internal_error;	// what to do when an internal error happens
+		bool			reject_unless_verified;
 
 		const Key*		get_key (const std::string& sender_address) const;	// Get HMAC key for the given sender
 												// (NULL if sender doesn't use BATV)
@@ -82,6 +83,7 @@ namespace batv {
 			address_lifetime = 7;
 			sub_address_delimiter = 0;
 			on_internal_error = FAILURE_TEMPFAIL;
+			reject_unless_verified = false;
 		}
 
 	};


### PR DESCRIPTION
It would be nice to have the option to inline-reject backscatter directly using batv-milter. Well, at least after a test phase when you are pretty sure there won't be false positives.

With this code, the admin is able to enforce this, simply by adding "reject-unless-verified = true" to the config.
